### PR TITLE
Use non-copyable types as state machines

### DIFF
--- a/Sources/DNSModels/ResourceRecords/RData/CAA.swift
+++ b/Sources/DNSModels/ResourceRecords/RData/CAA.swift
@@ -173,7 +173,7 @@ extension CAA.Value {
         }
     }
 
-    enum ParsingState {
+    enum ParsingState: ~Copyable {
         case beforeKey([(key: String, value: String)])
         case key(
             isFirstChar: Bool,
@@ -226,7 +226,7 @@ extension CAA.Value {
 
         // run the state machine through all remaining data, collecting all parameter tag/value pairs.
         while let char = buffer.readInteger(as: UInt8.self) {
-            switch state {
+            switch consume state {
             // name was already successfully parsed, otherwise we couldn't get here.
             case let .beforeKey(keyValues):
                 switch char {

--- a/Sources/DNSModels/ResourceRecords/RData/OPT.swift
+++ b/Sources/DNSModels/ResourceRecords/RData/OPT.swift
@@ -145,7 +145,7 @@ public struct OPT: Sendable {
 }
 
 extension OPT {
-    enum OptReadingState {
+    enum OptReadingState: ~Copyable {
         case readCode
         case code(code: EDNSCode)
         case data(code: EDNSCode, length: UInt16)
@@ -156,7 +156,7 @@ extension OPT {
         self.options = []
 
         while buffer.readableBytes != 0 {
-            switch state {
+            switch consume state {
             case .readCode:
                 state = .code(code: try EDNSCode(from: &buffer))
             case .code(let code):
@@ -187,7 +187,7 @@ extension OPT {
         case .readCode: break
         default:
             /// FIXME: do something about warnings logs
-            print("Incomplete or poorly formatted EDNS options: \(state)")
+            print("Incomplete or poorly formatted EDNS options")
             options.removeAll(keepingCapacity: false)
         }
     }

--- a/Sources/DNSModels/ResourceRecords/RecordTypeSet.swift
+++ b/Sources/DNSModels/ResourceRecords/RecordTypeSet.swift
@@ -6,7 +6,7 @@ public struct RecordTypeSet: Sendable {
 }
 
 extension RecordTypeSet {
-    enum BitMapReadingState {
+    enum BitMapReadingState: ~Copyable {
         case window
         case len(window: UInt8)
         case recordType(window: UInt8, bitMapLength: UInt8, left: UInt8)
@@ -65,7 +65,7 @@ extension RecordTypeSet {
 
         /// Loop through all the bytes in the bitmap
         for currentByte in self.originalEncoding ?? [] {
-            switch state {
+            switch consume state {
             case .window:
                 state = .len(window: currentByte)
             case let .len(window):


### PR DESCRIPTION
Not all these are necessary, but I thought let's keep state machines consistent.